### PR TITLE
Use account id in stead of alias

### DIFF
--- a/src/lib/profile_set.js
+++ b/src/lib/profile_set.js
@@ -1,11 +1,11 @@
 export function createProfileSet(profiles, userInfo, settings) {
   const {
-    loginDisplayNameAccount, loginDisplayNameUser,
+    userAccountNumber, loginDisplayNameUser,
     roleDisplayNameAccount, roleDisplayNameUser,
   } = userInfo;
   const { showOnlyMatchingRoles } = settings;
 
-  const baseAccount = brushAccountId(loginDisplayNameAccount);
+  const baseAccount = brushAccountId(userAccountNumber);
   const loginRole = extractLoginRole(loginDisplayNameUser.split("/", 2)[0]);
   const filterByTargetRole = showOnlyMatchingRoles ? (roleDisplayNameUser || loginRole) : null;
 

--- a/src/lib/profile_set.js
+++ b/src/lib/profile_set.js
@@ -6,7 +6,7 @@ export function createProfileSet(profiles, userInfo, settings) {
   const { showOnlyMatchingRoles } = settings;
 
   const baseAccount = brushAccountId(loginDisplayNameAccount);
-  const loginRole = loginDisplayNameUser.split("/", 2)[0]
+  const loginRole = extractLoginRoleFromSSO(loginDisplayNameUser.split("/", 2)[0])
   const filterByTargetRole = showOnlyMatchingRoles ? (roleDisplayNameUser || loginRole) : null;
 
   return new ProfileSet(profiles, baseAccount, { loginRole, filterByTargetRole });
@@ -77,4 +77,13 @@ function brushAccountId(val) {
   const r = val.match(/^(\d{4})\-(\d{4})\-(\d{4})$/);
   if (!r) return val;
   return r[1] + r[2] + r[3];
+}
+
+const awsSsoReserved = "AWSReservedSSO_";
+function extractLoginRoleFromSSO(loginRole) {
+  if (loginRole.startsWith(awsSsoReserved)) {
+    var lastUnderscore = loginRole.lastIndexOf('_');
+    loginRole = loginRole.substr(awsSsoReserved.length, lastUnderscore-awsSsoReserved.length);
+  }
+  return loginRole
 }


### PR DESCRIPTION
The property userAccountNumber contains the account id. If an account has an alias configured, the property loginDisplayNameAccount contains the alias.
Using the account id, leads to a stable config as the number is immutable.