### PR TITLE
limit displayname to 64 characters (#244)

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -132,7 +132,7 @@ a:hover {
     </div>
   </div>
 </div>
-<script src="js/popup.js"></script>
+<script src="js/popup.js" charset="utf-8"></script>
 <div id="sandbox" style="display: none;"></div>
 </body>
 </head>

--- a/src/lib/create_role_list_item.js
+++ b/src/lib/create_role_list_item.js
@@ -56,7 +56,7 @@ function createRedirectUri(currentUrl, curRegion, destRegion) {
   return encodeURIComponent(redirectUri);
 }
 
-function createDisplayName(profile, aws_account_id) {
+function createDisplayName(profile, awsAccountId) {
   const maxLength = 64;
   const separator = '  |  ';
   const overflow = '…';
@@ -64,8 +64,8 @@ function createDisplayName(profile, aws_account_id) {
   let displayName = profile;
   let totalLength = displayName.length;
 
-  if (aws_account_id !== undefined) {
-    totalLength += separator.length + aws_account_id.length;
+  if (awsAccountId !== undefined) {
+    totalLength += separator.length + awsAccountId.length;
   }
 
   if (totalLength > maxLength) {
@@ -73,8 +73,8 @@ function createDisplayName(profile, aws_account_id) {
                   + overflow;
   }
 
-  if (aws_account_id !== undefined) {
-    displayName += separator + aws_account_id;
+  if (awsAccountId !== undefined) {
+    displayName += separator + awsAccountId;
   }
   
   return displayName;

--- a/src/lib/create_role_list_item.js
+++ b/src/lib/create_role_list_item.js
@@ -58,14 +58,14 @@ function createRedirectUri(currentUrl, curRegion, destRegion) {
 
 function createDisplayName(profile, aws_account_id) {
   const maxLength = 64;
-  const seperator = '  |  ';
-  const overflow = '...';
+  const separator = '  |  ';
+  const overflow = '…';
 
   let displayName = profile;
   let totalLength = displayName.length;
 
   if (aws_account_id !== undefined) {
-    totalLength += seperator.length + aws_account_id.length;
+    totalLength += separator.length + aws_account_id.length;
   }
 
   if (totalLength > maxLength) {
@@ -74,7 +74,7 @@ function createDisplayName(profile, aws_account_id) {
   }
 
   if (aws_account_id !== undefined) {
-    displayName += seperator + aws_account_id;
+    displayName += separator + aws_account_id;
   }
   
   return displayName;

--- a/src/lib/create_role_list_item.js
+++ b/src/lib/create_role_list_item.js
@@ -27,9 +27,9 @@ export function createRoleListItem(document, item, url, region, { hidesAccountId
   anchor.appendChild(document.createTextNode(item.profile));
 
   if (hidesAccountId) {
-    anchor.dataset.displayname = item.profile;
+    anchor.dataset.displayname = createDisplayName(item.profile);
   } else {
-    anchor.dataset.displayname = item.profile + '  |  ' + item.aws_account_id;
+    anchor.dataset.displayname = createDisplayName(item.profile, item.aws_account_id);
 
     const accountIdSpan = document.createElement('span');
     accountIdSpan.className = 'suffixAccountId';
@@ -54,4 +54,28 @@ function createRedirectUri(currentUrl, curRegion, destRegion) {
     redirectUri = redirectUri.replace('region=' + curRegion, 'region=' + destRegion);
   }
   return encodeURIComponent(redirectUri);
+}
+
+function createDisplayName(profile, aws_account_id) {
+  const maxLength = 64;
+  const seperator = '  |  ';
+  const overflow = '...';
+
+  let displayName = profile;
+  let totalLength = displayName.length;
+
+  if (aws_account_id !== undefined) {
+    totalLength += seperator.length + aws_account_id.length;
+  }
+
+  if (totalLength > maxLength) {
+    displayName = displayName.substring(0, displayName.length - (totalLength - maxLength) - overflow.length)
+                  + overflow;
+  }
+
+  if (aws_account_id !== undefined) {
+    displayName += seperator + aws_account_id;
+  }
+  
+  return displayName;
 }


### PR DESCRIPTION
This is a potential fix for #244 - display names over 64 characters cause a 400 response when attempting to switch roles.
The change truncates the role name when the total display name length would exceed the limit while leaving the account ID whole (if enabled).