### PR TITLE
Add spaces around region

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ color = ffaaee
 [anotheraccount]
 aws_account_id = 987654321987
 role_name = anotherrole
-region=ap-northeast-1
+region = ap-northeast-1
 
 [athirdaccount]
 aws_account_id = 987654321988


### PR DESCRIPTION
Region setting doesn't work from the standard AWS role switcher if configured region doesn't have spaces around `=`, as in ~`region=region=ap-northeast-1`~.  Update readme to have spaces like `region = region=ap-northeast-1` to reflect this.