### PR TITLE
Support manifest v3 in Chrome

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,4 @@
 {
-  "version": "2.3.1",
   "name": "AWS Extend Switch Roles",
   "description": "Extend your AWS IAM switching roles. You can set the configuration like aws config format",
   "short_name": "Extend SwitchRole",
@@ -7,11 +6,6 @@
   "icons" : {
     "48": "icons/Icon_48x48.png",
     "128": "icons/Icon_128x128.png"
-  },
-  "browser_action": {
-    "default_title": "AWS Extend Switch Roles",
-    "default_icon": "icons/Icon_38x38.png",
-    "default_popup": "popup.html"
   },
   "content_scripts": [
     {
@@ -31,16 +25,5 @@
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
-  },
-  "web_accessible_resources": [
-    "js/attach_target.js"
-  ],
-  "commands": {
-    "_execute_browser_action": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+Comma"
-      }
-    }
-  },
-  "manifest_version": 2
+  }
 }

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -1,9 +1,29 @@
 {
-  "minimum_chrome_version": "80",
+  "version": "2.3.1",
+  "action": {
+    "default_title": "AWS Extend Switch Roles",
+    "default_icon": "icons/Icon_38x38.png",
+    "default_popup": "popup.html"
+  },
+  "web_accessible_resources": [{
+    "resources": ["js/attach_target.js"],
+    "matches": [
+      "https://*.console.aws.amazon.com/*",
+      "https://phd.aws.amazon.com/*",
+      "https://*.console.amazonaws-us-gov.com/*",
+      "https://*.console.amazonaws.cn/*"
+    ]
+  }],
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Comma"
+      }
+    }
+  },
   "background": {
-    "scripts": [
-      "js/background.js"
-    ],
-    "persistent": false
-  }
+    "service_worker": "js/background.js",
+    "type": "module"
+  },
+  "manifest_version": 3
 }

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,13 +1,30 @@
 {
+  "version": "2.3.1",
   "applications": {
     "gecko": {
       "id": "aws-extend-switch-roles@toshi.tilfin.com",
       "strict_min_version": "74.0"
     }
   },
+  "browser_action": {
+    "default_title": "AWS Extend Switch Roles",
+    "default_icon": "icons/Icon_38x38.png",
+    "default_popup": "popup.html"
+  },
   "background": {
     "scripts": [
       "js/background.js"
     ]
-  }
+  },
+  "web_accessible_resources": [
+    "js/attach_target.js"
+  ],
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Comma"
+      }
+    }
+  },
+  "manifest_version": 2
 }

--- a/src/content.js
+++ b/src/content.js
@@ -45,7 +45,7 @@ let accountInfo = null;
 function loadInfo(cb) {
   if (!accountInfo) {
     const script = document.createElement('script');
-    script.src = chrome.extension.getURL('/js/attach_target.js');
+    script.src = chrome.runtime.getURL('/js/attach_target.js');
     script.onload = function() {
       const json = document.getElementById('AESR_info').dataset.content;
       accountInfo = JSON.parse(json);

--- a/src/supporters.js
+++ b/src/supporters.js
@@ -1,13 +1,18 @@
 import { validateKeyCode } from './lib/verify_jwt'
-import { SyncStorageRepository } from './lib/storage_repository'
+import { LocalStorageRepository, SyncStorageRepository } from './lib/storage_repository'
 
 const syncStorageRepo = new SyncStorageRepository(chrome || browser)
+const localStorageRepo = new LocalStorageRepository(chrome || browser)
 
 function updateKeyExpire(exp) {
   syncStorageRepo.set({ goldenKeyExpire: exp })
   .then(() => {
-    localStorage.setItem('hasGoldenKey', exp ? exp : '');
-    chrome.browserAction.setIcon({ path: `icons/Icon_48x48${exp ? '_g' : ''}.png` });
+    localStorageRepo.set({ hasGoldenKey: exp ? exp : '' }).then(() => {})
+    if (chrome.action) {
+      chrome.action.setIcon({ path: `icons/Icon_48x48${exp ? '_g' : ''}.png` });
+    } else {
+      chrome.browserAction.setIcon({ path: `icons/Icon_48x48${exp ? '_g' : ''}.png` });
+    }
   })
 }
 


### PR DESCRIPTION
**English version of the text follows below the Japanese** 🙏 

---
# 概要
Chrome拡張機能は、2023年1月までにmanifest v2からv3に移行する必要があります。このプルリクエストはその移行の対応をしました。

manifest v3への移行について、いくつかリンクを載せます。もしご存知でしたら申し訳ございません。

- [Chromeでのmanifest v2のサポート期限についての記事](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/)
- [「Google Chrome 88」がリリース ～“Manifest V3”で拡張機能はより安全・高速に【1月22日追記】 - 窓の杜](https://forest.watch.impress.co.jp/docs/news/1301206.html)
- [Migrating to Manifest V3 - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/)

# 変更の詳細
公式ドキュメントに掲載されている移行手順 [Migrating to Manifest V3 - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/) に沿って変更しました。変更の概要は以下のとおりです。

- `manifest_version` を2から3へ
    - 参考：[Manifest version](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#manifest-version)
- `Service worker` として動くようにmanifest・scriptを変更
    - Service workerではlocalStorageが使用できないようなので、本拡張機能で書かれていたchrome.storageのラッパー`LocalStorageRepository` を使って書き換えました
    - 参考：[Service worker1](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#man-sw)、[Service workers2](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers)
- Action APIの統合
    - `browser_action` と`page_action` が統合され、`action` になりました。それに伴ってmanifest・APIともに変更しています
    - 参考：[Action API unification](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#action-api-unification)
- Web-accessible resourcesの変更
    - 参考：[Web-accessible resources](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#web-accessible-resources)
- 廃止されたAPIの置換
    - `chrome.extension.getURL`→ `chrome.runtime.getURL`
    - 参考：[Sunset for deprecated APIs](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#sunset-deprecated-apis)

# その他
- このPRでは機能変更は行っていません。Chromeのmanifest v3対応のみです
- `npm run test` → 31 passing
- 私の手元にあるMacのChrome・Firefoxでの動作確認は行いましたが、できればtilfinさんの手元の環境でも動作確認をお願いしたいです

---

# Overview
Chrome extensions must migrate from manifest v2 to v3 by January 2023. This pull request addresses that migration.

I will post some links regarding the migration to manifest v3. If you know of any, I apologize.

- [article about the expiration of manifest v2 support in Chrome](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/)
- [「Google Chrome 88」がリリース ～“Manifest V3”で拡張機能はより安全・高速に【1月22日追記】 - 窓の杜](https://forest.watch.impress.co.jp/docs/news/1301206.html)
- [Migrating to Manifest V3 - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/)

# Change Details
Migration instructions in the official documentation [Migrating to Manifest V3 - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/). Here is a summary of the changes

- `manifest_version` from 2 to 3
  - Reference: [Manifest version](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#manifest-version)
- Changed manifest & script to work as `Service worker`
    - Since localStorage does not seem to be available for Service workers, I rewrote it using the `LocalStorageRepository` wrapper for chrome.storage that was written in this extension.
    - Reference: [Service worker1,](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#man-sw) [Service workers2](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers)
- Action API unification
    - The `browser_action` and `page_action` have been merged into `action`. Therefore, both manifest and API have been changed.
    - Reference: [Action API unification](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#action-api-unification)
- Web-accessible resources has been changed
  - Reference: [Web-accessible resources](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#web-accessible-resources)
- Replacement of deprecated APIs
    - `chrome.extension.getURL` -> `chrome.runtime.getURL`.
    - Reference: [Sunset for deprecated APIs](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#sunset-deprecated-apis)

# etc.
- This PR does not change functionality, only Chrome manifest v3 support.
- `npm run test` → 31 passing
- I have tested it with Chrome and Firefox on my Mac, but I'd appreciate it if you could check it with your own environment if possible