### PR TITLE
Clearer error message when account ID doesn't exist

### DIFF
--- a/src/lib/load_aws_config.js
+++ b/src/lib/load_aws_config.js
@@ -62,7 +62,7 @@ class AwsConfigIniParser {
       delete item.role_arn;
     }
 
-    if (!item.aws_account_id) throw new Error('invalid profile definition whose the AWS account id is not specified')
+    if (!item.aws_account_id) throw new Error('Found a profile definition which does not include an AWS account id')
 
     return item;
   }


### PR DESCRIPTION
I find "Failed to save because invalid profile definition whose the AWS account id is not specified" a somewhat confusing error message and find this one easier to understand where my config is wrong.