### PR TITLE
Fix the error when pop-up closed after switching

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -78,6 +78,7 @@ function setupMessageListener(metaASE) {
       form.roleName.value = data.rolename;
       form.displayName.value = data.displayname;
       form.redirect_uri.value = data.redirecturi;
+      cb();
       form.submit();
       return false;
     }


### PR DESCRIPTION
It was caused by forgetting to send a callback.