### PR TITLE
Change content_scripts.matches

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,9 +17,12 @@
     {
       "matches": [
         "https://*.console.aws.amazon.com/*",
-        "https://phd.aws.amazon.com/*",
+        "https://health.aws.amazon.com/*",
+        "https://lightsail.aws.amazon.com/*",
         "https://*.console.amazonaws-us-gov.com/*",
-        "https://*.console.amazonaws.cn/*"
+        "https://phd.amazonaws-us-gov.com/*",
+        "https://*.console.amazonaws.cn/*",
+        "https://phd.amazonaws.cn/*"
       ],
       "all_frames": true,
       "js": [


### PR DESCRIPTION
#264

and dashboard URL phd.aws.amazon.com is replaced with health.aws.amazon.com.