### PR TITLE
Display message to save config when firefox private browsing

### DIFF
--- a/src/js/lib/db.js
+++ b/src/js/lib/db.js
@@ -22,7 +22,7 @@ export class DBManager {
         }
       };
       openReq.onerror = (event) => {
-        reject(`Error opening database: ${event.target.error}`);
+        reject(event.target.error);
       };
     });
   }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -46,7 +46,11 @@ window.onload = function() {
         }, 2500);
       })
       .catch(lastError => {
-        updateMessage(msgSpan, lastError.message, 'warn');
+        let msg = lastError.message
+        if (lastError.message === "A mutation operation was attempted on a database that did not allow mutations.") {
+          msg = "Configuration cannot be saved while using Private Browsing."
+        }
+        updateMessage(msgSpan, msg, 'warn');
       });
     } catch (e) {
       updateMessage(msgSpan, `Failed to save because ${e.message}`, 'warn');


### PR DESCRIPTION
Private browsing in Firefox does not allow saving to IndexedDB and displays an error message to that effect.