### PR TITLE
Add Profile Name and Line Number to Config Save Error Messages

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -83,7 +83,7 @@ window.onload = function() {
         if (lastError.message === "A mutation operation was attempted on a database that did not allow mutations.") {
           msg = "Configuration cannot be saved while using Private Browsing."
         }
-        updateMessage('msgSpan', msg, 'warn');
+        updateMessage('msgSpan', msg, 'warn', scrapeProfileName(textArea.value, lastError.line));
       });
     } catch (e) {
       updateMessage('msgSpan', `Failed to save because ${e.message}`, 'warn');
@@ -217,10 +217,21 @@ async function saveConfiguration(text, storageArea) {
   await localRepo.set({ profilesTableUpdated: now });
 }
 
-function updateMessage(elId, msg, cls = 'success') {
+function scrapeProfileName(text, line) {
+  if (!line) {
+    return;
+  }
+  let lines = text.split("\n");
+  return `[${lines[line - 1].split('[').pop().split(']')[0]}]:${line}`;
+}
+
+function updateMessage(elId, msg, cls = 'success', profile) {
   const el = elById(elId);
   const span = document.createElement('span');
   span.className = cls;
+  if (profile) {
+    msg += " " + profile;
+  }
   span.textContent = msg;
   const child = el.firstChild;
   if (child) {


### PR DESCRIPTION
Adds profile name and line number to error messages during configuration save in the format: ` [profile_name]:##`, or in the case that the profile name is not in the line (such as invalid parameter definition), grabs the value of the line: ` [line_value]:##`

Addresses https://github.com/tilfinltd/aws-extend-switch-roles/issues/338 as I have run into the same issue multiple times. 

Affects only ConfigLoadError/IniParseError that already supply a line-number from aesr-config:
  - "The profile includes both `role_arn` and either `aws_account_id` or `role_name`."
  - "The profile includes invalid `role_arn` parameter."
  - "The profile doesn't specify an AWS account ID."
  - "Invalid parameter definition"

Tested in Chrome and Firefox on MacOS 14.4.1 with the same results.
<img width="1512" alt="chrome-invalid_role_arn" src="https://github.com/tilfinltd/aws-extend-switch-roles/assets/61980807/dfb6fdc4-a9bf-4e17-8966-ef794552c2dd">
<img width="1512" alt="chrome-aws_account_not_specified" src="https://github.com/tilfinltd/aws-extend-switch-roles/assets/61980807/d9269dae-2fe2-4867-9ff5-f1eac490ccca">
<img width="1512" alt="chrome-invalid_param" src="https://github.com/tilfinltd/aws-extend-switch-roles/assets/61980807/c7ed9284-f324-48bc-a987-be4edadd04ab">
<img width="1512" alt="chrome-conflicting_options" src="https://github.com/tilfinltd/aws-extend-switch-roles/assets/61980807/b00f505d-0f79-4ded-9bf9-5ac0b8c37d12">
