### PR TITLE
Support filtering roles that contain a path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-extend-switch-roles",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-extend-switch-roles",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "aesr-config": "^0.4.1"

--- a/src/js/lib/target_profiles.js
+++ b/src/js/lib/target_profiles.js
@@ -28,7 +28,7 @@ async function retrieveTargetProfilesFromDB(ctx) {
       const complexTargetItems = await dbTable.query(`${matchedComplexSrc.name};`);
       let targets = complexTargetItems.map(it => convertComplexTarget(it, matchedComplexSrc));
       if (filterByTargetRole) {
-        targets = targets.filter(it => it.role_name === filterByTargetRole);
+        targets = targets.filter(it => targetRoleNameMatches(it, filterByTargetRole));
       }
       results.push(...targets)
     }
@@ -72,10 +72,14 @@ async function retrieveTargetProfilesFromLztext(ctx) {
   if (matchedComplexSrc) {
     let targets = matchedComplexSrc.targets;
     if (filterByTargetRole) {
-      targets = targets.filter(it => it.role_name === filterByTargetRole);
+      targets = targets.filter(it => targetRoleNameMatches(it, filterByTargetRole));
     }
     results.push(...targets)
   }
 
   return results;
+}
+
+function targetRoleNameMatches(it, filterByTargetRole) {
+  return it.role_name === filterByTargetRole || it.role_name.substring(it.role_name.lastIndexOf('/') + 1) === filterByTargetRole;
 }


### PR DESCRIPTION
In my organisation some roles have been created with paths:
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names

This PR extends the matching logic to match on roles with a path